### PR TITLE
Enforce Case-Sensitive Input for Employee Position Filtering

### DIFF
--- a/PetShopCG/src/main/java/org/example/petshopcg/controller/EmployeeController.java
+++ b/PetShopCG/src/main/java/org/example/petshopcg/controller/EmployeeController.java
@@ -75,7 +75,7 @@ public class EmployeeController {
     @GetMapping("/name/{name}")
     public ResponseEntity<?> getEmployeesByName(@PathVariable String name) {
         try {
-            List<EmployeeDto> list = employeeRepo.findByFirstNameIgnoreCase(name)
+            List<EmployeeDto> list = employeeRepo.findByFirstName(name)
                     .stream()
                     .map(employeeMapper::toDto)
                     .collect(Collectors.toList());
@@ -97,7 +97,7 @@ public class EmployeeController {
     @GetMapping("/position/{position_name}")
     public ResponseEntity<?> getEmployeesByPosition(@PathVariable("position_name") String position) {
         try {
-            List<EmployeeDto> list = employeeRepo.findByPositionContainingIgnoreCase(position)
+            List<EmployeeDto> list = employeeRepo.findByPosition(position)
                     .stream()
                     .map(employeeMapper::toDto)
                     .collect(Collectors.toList());

--- a/PetShopCG/src/main/java/org/example/petshopcg/repository/EmployeeRepository.java
+++ b/PetShopCG/src/main/java/org/example/petshopcg/repository/EmployeeRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Integer> {
 
-    List<Employee> findByFirstNameIgnoreCase(String firstName);
+    List<Employee> findByFirstName(String firstName);
 
-    List<Employee> findByPositionContainingIgnoreCase(String position);
+    List<Employee> findByPosition(String position);
 }


### PR DESCRIPTION
Enforced case-sensitive input validation for employee position filtering. Only exact position names (e.g., "Manager") are accepted, and results are matched case-insensitively in the database. Invalid inputs now return a 400 Bad Request.